### PR TITLE
Crash when warping with dead player

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1485,9 +1485,9 @@ function warptorio.Warpout(vplanet)
 
 	-- Recreate teleporter gate
 	if(gwarptorio.Teleporters.offworld)then warptorio.Teleporters.offworld:Warpin() end
-	for k,v in pairs(game.players)do if(v and v.valid)then local iv=v.get_main_inventory() for i,x in pairs(iv.get_contents())do
+	for k,v in pairs(game.players)do if(v and v.valid)then local iv=v.get_main_inventory() if(iv) then for i,x in pairs(iv.get_contents())do
 		if(i:sub(1,25)=="warptorio-teleporter-gate")then iv.remove{name=i,count=x} end
-	end end end
+	end end end end
 
 	--// cleanup past entities
 	


### PR DESCRIPTION
I had a crash when the warp triggered while I was waiting to respawn
```
2635.732 Error MainLoop.cpp:1199: Exception at tick 292200: The mod Warptorio2 caused a non-recoverable error.
Please report this error to the mod author.

Error while running event warptorio2::on_tick (ID 0)
__warptorio2__/control.lua:1546: attempt to index local 'iv' (a nil value)
stack traceback:
	__warptorio2__/control.lua:1546: in function 'Warpout'
	__warptorio2__/control.lua:988: in function 'TickTimers'
	__warptorio2__/control.lua:1041: in function <__warptorio2__/control.lua:1027>
```
Fixed by making sure the inventory exists before looking through it.