### PR TITLE
Item cleanup

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -67,8 +67,12 @@ local t=ExtendDataCopy("tile","tutorial-grid",{name="warptorio-red-concrete",tin
 local rtint={r=0.4,g=0.4,b=1,a=1}
 local rvtint={scale=1/3,shift={0.03125/3,-0.5/3},tint={r=1,g=1,b=1,a=0},hr_version={scale=0.5/3,tint={r=1,g=1,b=1,a=0},shift={0.03125/3,-0.5/3}}}
 local r=ExtendDataCopy("radar","radar",{name="warptorio-invisradar",
-	icon=false,icons={{icon="__base__/graphics/icons/radar.png",tint=rtint}},integration_patch=rvtint,pictures={layers={rvtint,rvtint}},
-},true,{energy_per_nearby_scan="10kJ",energy_per_sector="200kJ",energy_usage="1kW",
+	icons={{icon="__base__/graphics/icons/radar.png",tint=rtint}},
+	integration_patch=rvtint,
+	pictures={layers={rvtint,rvtint}},
+	minable=nil,
+	order="warptorio"
+},{energy_per_nearby_scan="10kJ",energy_per_sector="200kJ",energy_usage="1kW",
 	max_distance_of_nearby_sector_revealed=5,max_distance_of_sector_revealed=18,
 	collision_box={{-1.2/3,-1.2/3},{1.2/3,1.2/3}},selection_box={{-1.5/3,-1.5/3},{1.5/3,1.5/3}},
 })

--- a/data_accumulators.lua
+++ b/data_accumulators.lua
@@ -100,7 +100,9 @@ local t=ExtendDataCopy("accumulator","warptorio-teleporter-gate-0",{name="warpto
 -- ----
 -- Stairways
 
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-underground-0",energy_source={buffer_capacity="2MJ",input_flow_limit="5MW",output_flow_limit="5MW"},},{
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{
+	name="warptorio-underground-0",
+	energy_source={buffer_capacity="2MJ",input_flow_limit="5MW",output_flow_limit="5MW"},
 	minable=nil,
 	order="warptorio",
 	picture={layers={

--- a/data_accumulators.lua
+++ b/data_accumulators.lua
@@ -72,31 +72,37 @@ local t={
 data:extend{t}
 ExtendRecipeItem(t)
 
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-teleporter-1",energy_source={buffer_capacity="4MJ",input_flow_limit="2MW",output_flow_limit="2MW"}},true)
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-teleporter-2",energy_source={buffer_capacity="8MJ",input_flow_limit="20MW",output_flow_limit="20MW"}},true)
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-teleporter-3",energy_source={buffer_capacity="16MJ",input_flow_limit="200MW",output_flow_limit="200MW"}},true)
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-teleporter-4",energy_source={buffer_capacity="32MJ",input_flow_limit="2000MW",output_flow_limit="2000MW"}},true)
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-teleporter-5",energy_source={buffer_capacity="64MJ",input_flow_limit="20000MW",output_flow_limit="20000MW"}},true)
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-teleporter-1",energy_source={buffer_capacity="4MJ",input_flow_limit="2MW",output_flow_limit="2MW"}})
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-teleporter-2",energy_source={buffer_capacity="8MJ",input_flow_limit="20MW",output_flow_limit="20MW"}})
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-teleporter-3",energy_source={buffer_capacity="16MJ",input_flow_limit="200MW",output_flow_limit="200MW"}})
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-teleporter-4",energy_source={buffer_capacity="32MJ",input_flow_limit="2000MW",output_flow_limit="2000MW"}})
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-teleporter-5",energy_source={buffer_capacity="64MJ",input_flow_limit="20000MW",output_flow_limit="20000MW"}})
 
 -- --------
 -- Teleporter Gate
 
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-teleporter-gate-0",minable={mining_time=2,result="warptorio-teleporter-gate-0"},
-	picture={layers={[1]={ tint={r=1,g=0.8,b=0.8,a=0.6}, hr_version={tint={r=1,g=0.8,b=0.8,a=0.6}}, } }}, })
-local t=ExtendDataCopy("recipe","lab",{name="warptorio-teleporter-gate-0",enabled=false})
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{
+	name="warptorio-teleporter-gate-0",
+	minable={mining_time=2,result="warptorio-teleporter-gate-0"},
+	order="warptorio",
+	picture={layers={[1]={ tint={r=1,g=0.8,b=0.8,a=0.6}, hr_version={tint={r=1,g=0.8,b=0.8,a=0.6}}} }},
+ })
+--local t=ExtendDataCopy("recipe","lab",{name="warptorio-teleporter-gate-0",enabled=false})
 local t=ExtendDataCopy("item","lab",{name="warptorio-teleporter-gate-0",place_result="warptorio-teleporter-gate-0",
 	icons={{ icon="__base__/graphics/icons/lab.png", tint={r=1,g=0.6,b=0.6,a=0.6}, }}, })
 
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-gate-0",{name="warptorio-teleporter-gate-1",energy_source={buffer_capacity="4MJ",input_flow_limit="2MW",output_flow_limit="2MW"}},true)
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-gate-0",{name="warptorio-teleporter-gate-2",energy_source={buffer_capacity="8MJ",input_flow_limit="20MW",output_flow_limit="20MW"}},true)
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-gate-0",{name="warptorio-teleporter-gate-3",energy_source={buffer_capacity="16MJ",input_flow_limit="200MW",output_flow_limit="200MW"}},true)
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-gate-0",{name="warptorio-teleporter-gate-4",energy_source={buffer_capacity="32MJ",input_flow_limit="2GW",output_flow_limit="2GW"}},true)
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-gate-0",{name="warptorio-teleporter-gate-5",energy_source={buffer_capacity="64MJ",input_flow_limit="20GW",output_flow_limit="20GW"}},true)
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-gate-0",{name="warptorio-teleporter-gate-1",energy_source={buffer_capacity="4MJ",input_flow_limit="2MW",output_flow_limit="2MW"}})
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-gate-0",{name="warptorio-teleporter-gate-2",energy_source={buffer_capacity="8MJ",input_flow_limit="20MW",output_flow_limit="20MW"}})
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-gate-0",{name="warptorio-teleporter-gate-3",energy_source={buffer_capacity="16MJ",input_flow_limit="200MW",output_flow_limit="200MW"}})
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-gate-0",{name="warptorio-teleporter-gate-4",energy_source={buffer_capacity="32MJ",input_flow_limit="2GW",output_flow_limit="2GW"}})
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-gate-0",{name="warptorio-teleporter-gate-5",energy_source={buffer_capacity="64MJ",input_flow_limit="20GW",output_flow_limit="20GW"}})
 
 -- ----
 -- Stairways
 
-local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-underground-0",energy_source={buffer_capacity="2MJ",input_flow_limit="5MW",output_flow_limit="5MW"},},true,{
+local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-underground-0",energy_source={buffer_capacity="2MJ",input_flow_limit="5MW",output_flow_limit="5MW"},},{
+	minable=nil,
+	order="warptorio",
 	picture={layers={
 		[1]={ tint={r=0.8,g=0.8,b=1,a=1}, scale=0.9,
 			filename="__base__/graphics/entity/electric-furnace/electric-furnace-base.png", priority="high", width=129, height=100, frame_count=1, shift={0.421875/2, 0},
@@ -114,11 +120,11 @@ local t=ExtendDataCopy("accumulator","warptorio-teleporter-0",{name="warptorio-u
 	}},
 })
 
-local t=ExtendDataCopy("accumulator","warptorio-underground-0",{name="warptorio-underground-1",energy_source={buffer_capacity="10MJ",input_flow_limit="500MW",output_flow_limit="500MW"},},true)
-local t=ExtendDataCopy("accumulator","warptorio-underground-0",{name="warptorio-underground-2",energy_source={buffer_capacity="50MJ",input_flow_limit="1GW",output_flow_limit="1GW"},},true)
-local t=ExtendDataCopy("accumulator","warptorio-underground-0",{name="warptorio-underground-3",energy_source={buffer_capacity="100MJ",input_flow_limit="2GW",output_flow_limit="2GW"},},true)
-local t=ExtendDataCopy("accumulator","warptorio-underground-0",{name="warptorio-underground-4",energy_source={buffer_capacity="500MJ",input_flow_limit="5GW",output_flow_limit="5GW"},},true)
-local t=ExtendDataCopy("accumulator","warptorio-underground-0",{name="warptorio-underground-5",energy_source={buffer_capacity="1GJ",input_flow_limit="20GW",output_flow_limit="20GW"},},true)
+local t=ExtendDataCopy("accumulator","warptorio-underground-0",{name="warptorio-underground-1",energy_source={buffer_capacity="10MJ",input_flow_limit="500MW",output_flow_limit="500MW"}})
+local t=ExtendDataCopy("accumulator","warptorio-underground-0",{name="warptorio-underground-2",energy_source={buffer_capacity="50MJ",input_flow_limit="1GW",output_flow_limit="1GW"}})
+local t=ExtendDataCopy("accumulator","warptorio-underground-0",{name="warptorio-underground-3",energy_source={buffer_capacity="100MJ",input_flow_limit="2GW",output_flow_limit="2GW"}})
+local t=ExtendDataCopy("accumulator","warptorio-underground-0",{name="warptorio-underground-4",energy_source={buffer_capacity="500MJ",input_flow_limit="5GW",output_flow_limit="5GW"}})
+local t=ExtendDataCopy("accumulator","warptorio-underground-0",{name="warptorio-underground-5",energy_source={buffer_capacity="1GJ",input_flow_limit="20GW",output_flow_limit="20GW"}})
 
 -- ----
 -- Warp Beacon
@@ -127,8 +133,10 @@ local t=ExtendDataCopy("beacon","beacon",{name="warptorio-beacon-1",supply_area_
 	base_picture={ tint={r=0.5,g=0.7,b=1,a=1}, }, animation={ tint={r=1,g=0.2,b=0.2,a=1}, },
 	allowed_effects={"consumption","speed","pollution","productivity"},
 	distribution_effectivity=1,
-},true)
-for i=2,10,1 do local xt=table.deepcopy(t) xt.name="warptorio-beacon-"..i xt.supply_area_distance=math.min(16+8*i,64) xt.module_specification.module_slots=i data:extend{xt} ExtendRecipeItem(xt) end
+	minable=nil,
+	order="warptorio"
+})
+for i=2,10,1 do local xt=table.deepcopy(t) xt.name="warptorio-beacon-"..i xt.supply_area_distance=math.min(16+8*i,64) xt.module_specification.module_slots=i data:extend{xt} end
 
 
 -- ----

--- a/data_warptorio-logistics-pipe.lua
+++ b/data_warptorio-logistics-pipe.lua
@@ -3,16 +3,16 @@ local rctint=rtint --{r=0.39,g=0,b=0,a=1}
 
 data:extend{
 
-    {
-      icons = {{icon="__base__/graphics/icons/pipe-to-ground.png",tint=rtint}},
-      icon_size = 32,
-      name = "warptorio-logistics-pipe",
-      order = "a[pipe]-b[pipe-to-ground]",
-      place_result = "warptorio-logistics-pipe",
-      stack_size = 50,
-      subgroup = "energy-pipe-distribution",
-      type = "item"
-    },
+    -- {
+    --   icons = {{icon="__base__/graphics/icons/pipe-to-ground.png",tint=rtint}},
+    --   icon_size = 32,
+    --   name = "warptorio-logistics-pipe",
+    --   order = "a[pipe]-b[pipe-to-ground]",
+    --   place_result = "warptorio-logistics-pipe",
+    --   stack_size = 50,
+    --   subgroup = "energy-pipe-distribution",
+    --   type = "item"
+    -- },
 
 
 {
@@ -178,10 +178,9 @@ data:extend{
       icon = "__base__/graphics/icons/pipe-to-ground.png",
       icon_size = 32,
       max_health = 150,
-      minable = {
-        mining_time = 0.1,
-        result = "pipe-to-ground"
-      },
+      minable = nil,
+      order = "warptorio",
+      items_to_place_this = {"underground-pipe"},
       name = "warptorio-logistics-pipe",
       pictures = {
         down = { tint=rctint,

--- a/data_warptorio-logistics-pipe.lua
+++ b/data_warptorio-logistics-pipe.lua
@@ -180,7 +180,7 @@ data:extend{
       max_health = 150,
       minable = nil,
       order = "warptorio",
-      items_to_place_this = {"underground-pipe"},
+      placeable_by = {item="pipe-to-ground", count=1},
       name = "warptorio-logistics-pipe",
       pictures = {
         down = { tint=rctint,

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "warptorio2",
-	"version": "1.1.0",
+	"version": "1.0.4",
 	"title": "Warptorio",
 	"author": "Nonoce and PyroFire",
 	"dependencies": ["base >= 0.17","! NewGamePlus","! space-exploration","! Rampant"],

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "warptorio2",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"title": "Warptorio",
 	"author": "Nonoce and PyroFire",
 	"dependencies": ["base >= 0.17","! NewGamePlus","! space-exploration","! Rampant"],


### PR DESCRIPTION
This removes some of the extra items and recipes in the scenario by applying the proper tags to the entities so they don't require items.

The underground pipe teleporter also gives a non-scenario pipe when targeted with the pipette tool.

For further development (not included in this PR), item and recipe generation can be split so the deployable teleporters do not include a recipe.  Additionally, it could be switched to use an EEI instead of an accumulator so a single entity could cover all levels or possibly even a continuous range.
