### PR TITLE
Fix warptorio.RemoveCacheFilter to actually remove the filters

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -491,7 +491,7 @@ function warptorio.InsertCacheLoader(v) warptorio.InsertCache("ld".. v.loader_ty
 function warptorio.RemoveCacheFilter(v) local ct=gwarptorio.cache["ldoutputf"]
 	for cidx,tbl in pairs(ct)do
 		local rd=false local rdxt={}
-		for id,e in pairs(tbl)do if(not isvalid(e) or e.owner==v)then table.insert(rdxt,v) end end
+		for id,e in pairs(tbl)do if(not isvalid(e) or e.owner==v)then table.insert(rdxt,e) end end
 		for k,x in pairs(rdxt)do table.RemoveByValue(tbl,x) end
 		if(table_size(tbl)==0)then ct[cidx]=nil end
 	end


### PR DESCRIPTION
The loader not the filter was being added to rdxt, meaning the
subsequent table.RemoveByValue loop did nothing.

Fixes: https://mods.factorio.com/mod/warptorio2/discussion/606df1269f8bb34d838abe66