### PR TITLE
Fixes for warptorio2 with locales crash

### DIFF
--- a/control_main.lua
+++ b/control_main.lua
@@ -931,12 +931,17 @@ function warptorio.WarpBuildPlanet(key)
 		local vplanet=warptorio.GetMainPlanet()
 		local lvl=research.level("warptorio-reactor")
 		if(lvl>=8)then local wx=global.planet_target
-			if(wx=="home" or wx=="nauvis")then if(research.has("warptorio-homeworld"))then local hf=(wx=="nauvis" and game.surfaces.nauvis or global.floor.home.host)
-				if(warptorio.GetMainSurface()~=hf and math.random(1,100)<=warptorio.setting("warpchance"))then local hp=remote.call("planetorio","GetBySurface",hf) or {name="Nauvis"}
-					game.print("-Successful Warp-") game.print(hp.name .. ". Home sweet home.")
-					return hf,hp
-				end
-			end elseif(wx and math.random(1,100)<=warptorio.setting("warpchance"))then
+			if(wx=="home" or wx=="nauvis") then 
+				if(research.has("warptorio-homeworld")) then
+					local hf=(wx=="nauvis" and game.surfaces.nauvis or global.floor.home.host)
+					if(warptorio.GetMainSurface()~=hf and math.random(1,100)<=warptorio.setting("warpchance")) then 
+						local hp=remote.call("planetorio","GetBySurface",hf) or {name="Nauvis"}
+						game.print("-Successful Warp-") 
+						game.print({"", hp.name, ". Home sweet home."})
+						return hf,hp
+					end
+				end 
+			elseif(wx and math.random(1,100)<=warptorio.setting("warpchance"))then
 				nplanet=remote.call("planetorio","FromTemplate","warpzone_"..global.warpzone,wx)
 				if(nplanet)then game.print("-Successful Warp-") end
 			end


### PR DESCRIPTION
…97f4663da68

https://mods.factorio.com/mod/warptorio2/discussion/62261ca6b671a97f4663da68

Error while running event warptorio2::on_tick (ID 0)
warptorio2/control_main.lua:938: attempt to concatenate field 'name' (a table value)
stack traceback:
warptorio2/control_main.lua:938: in function 'WarpBuildPlanet'
warptorio2/control_main.lua:850: in function 'Warpout'
warptorio2/control_main_helpers.lua:227: in function 'b'
warptorio2/lib/lib_control.lua:281: in function <warptorio2/lib/lib_control.lua:281>

Factorio version == 1.1.61 (build 59839, win64)
Mod list:
- Alien biomes==0.6.7
- Alien biomes High-res Terrain==0.6.1
- Base mod==1.1.61
- Bullet Trails==0.6.2
- Combat mechanics overhaul==0.6.22
- Explosive biters==1.1.36
- Factorio crash site==1.0.2
- Factorio library==0.8.3
- Frost biters==1.1.2
- Planetorio==0.1.3
- Planetorio Expansions Planets==1.0.3
- Warptorio2==1.3.9
- Warptorio2 Expansion==1.1.87